### PR TITLE
Add support for retrieving lot-specific section descriptions

### DIFF
--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -326,6 +326,11 @@ class ContentSection(object):
             if question.get('slug') == question_slug:
                 return question
 
+    def get_description_for_lot(self, lot_slug):
+        if hasattr(self.description, 'get'):
+            return self.description.get(lot_slug, self.description.get('default'))
+        return self.description
+
     def inject_brief_questions_into_boolean_list_question(self, brief):
         for question in self.questions:
             question.inject_brief_questions_into_boolean_list_question(brief)

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -669,6 +669,51 @@ class TestContentSection(object):
         })
         assert section.has_summary_page is True
 
+    def test_get_simple_string_description(self):
+        section = ContentSection.create({
+            'slug': 'first_section',
+            'name': 'First section',
+            'description': 'description',
+            'questions': [{
+                'id': 'q1',
+                'question': 'Boolean question',
+                'type': 'boolean',
+            }]
+        })
+        assert section.get_description_for_lot('a_lot') == 'description'
+
+    def test_get_compound_description(self):
+        section = ContentSection.create({
+            'slug': 'first_section',
+            'name': 'First section',
+            'description': {
+                'default': 'wrong',
+                'a_lot': 'description',
+            },
+            'questions': [{
+                'id': 'q1',
+                'question': 'Boolean question',
+                'type': 'boolean',
+            }]
+        })
+        assert section.get_description_for_lot('a_lot') == 'description'
+
+    def test_get_compound_description_default(self):
+        section = ContentSection.create({
+            'slug': 'first_section',
+            'name': 'First section',
+            'description': {
+                'default': 'description',
+                'some_other_lot': 'wrong',
+            },
+            'questions': [{
+                'id': 'q1',
+                'question': 'Boolean question',
+                'type': 'boolean',
+            }]
+        })
+        assert section.get_description_for_lot('a_lot') == 'description'
+
     def test_get_question_ids(self):
         section = ContentSection.create({
             "slug": "first_section",


### PR DESCRIPTION
Lot-specific sections descriptions themselves were added to the
frameworks repository in this commit:
https://github.com/AusDTO/dto-digitalmarketplace-frameworks/commit/718ab5888f36ab376b6cb0242d4d4b90ea5fa39c
